### PR TITLE
Turn off dot-imports rule in revive

### DIFF
--- a/pkg/tools/golang/golangci.yaml
+++ b/pkg/tools/golang/golangci.yaml
@@ -95,7 +95,6 @@ linters-settings:
       - name: blank-imports
       - name: context-as-argument
       - name: context-keys-type
-      - name: dot-imports
       - name: error-naming
       - name: error-return
       - name: error-strings


### PR DESCRIPTION
Dot imports are useful when writing assembler code using Avo.